### PR TITLE
docs(cmd): add copyright header to main files

### DIFF
--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -1,3 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
 package main
 
 import (

--- a/cmd/draftd/draftd.go
+++ b/cmd/draftd/draftd.go
@@ -1,3 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
 package main
 
 import (


### PR DESCRIPTION
In case a user misses the LICENSE file in the root directory, this is an additional cue that the project is MIT-licensed. This was requested by Microsoft's legal team for OSS approval.