### PR TITLE
fix tagging logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def isMaster = { String branch ->
 }
 
 def isTag = { String branch ->
-  branch.startsWith("remotes/origin/tags/")
+  branch.startsWith("tags/")
 }
 
 def deriveCommit = {


### PR DESCRIPTION
In a v0.3.0-rc2 job, the job failed to publish binaries and docker images with the following error message:

    git ref tags/v0.3.0-rc2 not releasable; skipping binary publishing.

So in order to fix this, we need to check for the branch reference beginning with "tags/" instead.

See https://ci.deis.io/blue/organizations/jenkins/Azure%2Fdraft/detail/release-v0.3.0/3/pipeline/31/ for more context