### PR TITLE
stop building app when client closes connection

### DIFF
--- a/pkg/draft/client.go
+++ b/pkg/draft/client.go
@@ -136,7 +136,7 @@ func (c Client) Up(appName, namespace string, out io.Writer, buildContext, chart
 	for {
 		_, p, err := conn.NextReader()
 		if err != nil {
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 				// server closed the connection, so we're done!
 				return nil
 			}


### PR DESCRIPTION
I haven't manually tested this yet, but the idea is that the server now reads from the client for a message. Normally it'll receive an error that it couldn't read a message, which is fine. When it reads a normal closure, abnormal closure or a going away close frame from the client, it will respond with its own close frame and finish the HTTP request, closing the websocket and the build operation along with it.